### PR TITLE
Tweak shop confirmation email

### DIFF
--- a/packages/lambda-send-payment/send-email.js
+++ b/packages/lambda-send-payment/send-email.js
@@ -87,12 +87,12 @@ div {
         ${displayItems(lineItems, '&pound;', '<br />')}
       </p>
       <p>Total value: &pound;${amount}</p>
-      <p>The address you submitted was:</p>
-      <p>${
-  [(`${firstName} ${lastName}`).trim(), address1, address2, address3, postCode].filter(Boolean).join('<br />')
-}</p>
-      <p>Your order will be submitted to the factory at the end of the month.</p>
-      <p>Once we know the delivery date for your items we'll let you know.</p>
+      <p>We aim to submit orders to the factory every two months.</p>
+      <p>
+        It then typically takes a further six weeks to print, after which your items will be held at
+        <a href="https://ratracecycles.com">Rat Race Cycles</a> for you to pick up.
+      </p>
+      <p>Once we know the delivery date for your items we'll send you an email to let you know.</p>
       <p>Please get in touch if you'd like any updates in the interim.</p>
       <p>Thank you,</p>
       <p>Peckham Cycle Club</p>
@@ -127,15 +127,11 @@ ${displayItems(lineItems, '£', '\r\n')}
 
 Total value: £${amount}
 
-The address you submitted was:
+We aim to submit orders to the factory every two months.
 
-${
-  [(`${firstName} ${lastName}`).trim(), address1, address2, address3, postCode].filter(Boolean).join('\r\n')
-}
+It then typically takes about six weeks to print, after which your items will be held at Rat Race Cycles for you to pick up.
 
-Your order will be submitted to the factory at the end of the month.
-
-Once we know the delivery date for your items we'll let you know.
+Once we know the delivery date for your items we'll send you an email to let you know.
 
 Please get in touch if you'd like any updates in the interim.
 

--- a/packages/website/src/components/basket.js
+++ b/packages/website/src/components/basket.js
@@ -281,7 +281,7 @@ class Basket extends Component {
           <Terms error={showTermsError}>
             <h4>Terms &amp; Conditions</h4>
             <p>All kit is made to order and cannot be cancelled, exchanged or refunded once your order has been placed.</p>
-            <p>Items from kit orders are sent to the factory when minimum quantities are reached and take 4-6 weeks to be made &amp; shipped.</p>
+            <p>We aim to send kit orders to the factory every two months, then it will take approximately 6 weeks to be made &amp; shipped.</p>
             <p>When items are available, your order will be available to be picked up from the most excellent <a href='https://ratracecycles.com/'>Rat Race Cycles</a> at 118 Evelina Road, SE15 3HL.</p>
             <p>We will be in touch to let you know the delivery date as soon as it is available and once items are ready for pick up.</p>
             <p>Please confirm you understand the above and are happy to proceed with your order:


### PR DESCRIPTION
We don't ship items to people's addresses, so playing back their address may be misleading. Instead tell people that their stuff is at rat race. Also, we don't contact people when items have been delivered so leave out that line so people aren't just waiting for comms that never comes.

Open to thoughts - this is more a request for comments rather than finalised words.

I'll update the Ts & Cs on the shop page as well - they still talk about minimum quantities.