### PR TITLE
fix: ensure product options are constant

### DIFF
--- a/packages/lambda-lib/stripe-client.js
+++ b/packages/lambda-lib/stripe-client.js
@@ -153,7 +153,8 @@ const getProducts = async () => {
       options,
       prices,
       type: product.metadata.type,
-      shippingWeight: parseInt(product.metadata['shipping-weight'] || '0', 10)
+      shippingWeight: parseInt(product.metadata['shipping-weight'] || '0', 10),
+      variations: product.metadata.options
     })
   }
 

--- a/packages/website/src/components/shop/product-details.jsx
+++ b/packages/website/src/components/shop/product-details.jsx
@@ -522,54 +522,6 @@ class ProductDetails extends Component {
     })
 
     const price = getPrice(product, options)
-    /*
-    let price = Object.values(product.prices)[0]
-
-    if (Object.keys(product.options).length) {
-      const chosen = []
-
-      for (const [key, value] of Object.entries(options)) {
-        if (key === 'size') {
-          // size does not affect price
-          continue
-        }
-
-        chosen.push(value)
-      }
-
-      const matrix = chosen.join('-')
-
-      console.info('matrix', matrix)
-
-      const codes = OPTIONS.productPrices[product.slug]
-
-      if (!codes) {
-        throw new Error(`No product prices defined in config for ${product.slug}`)
-      }
-
-      let code
-
-      if (matrix === '') {
-        if (typeof codes != 'string') {
-          throw new Error(`Product ${product.slug} only had size option but multiple configured prices`)
-        }
-
-        code = codes
-      } else {
-        code = codes[matrix]
-      }
-
-      if (!code) {
-        throw new Error(`No product price defined in config for ${product.slug} and selection ${matrix}`)
-      }
-
-      price = product.prices[code]
-
-      if (!price) {
-        throw new Error(`No product price defined for code ${code} for product ${product.slug}`)
-      }
-    }
-    */
 
     return (
       <ProductDetailsPanel>

--- a/packages/website/src/lib/products.js
+++ b/packages/website/src/lib/products.js
@@ -3,8 +3,6 @@ import {
 } from '@peckhamcc/config'
 
 export function getPrice (product, options) {
-  console.info('product', product, 'options', options)
-
   const codes = OPTIONS.productPrices[product.slug]
 
   if (!codes) {
@@ -13,16 +11,17 @@ export function getPrice (product, options) {
 
   let price = Object.values(product.prices)[0]
 
-  if (Object.keys(product.options).length) {
+  if (product.variations) {
     const chosen = []
 
-    for (const [key, value] of Object.entries(options)) {
+    // ensure the order is constant
+    for (const key of product.variations.split('-')) {
       if (key === 'size') {
         // size does not affect price
         continue
       }
 
-      chosen.push(value)
+      chosen.push(options[key])
     }
 
     const matrix = chosen.join('-')


### PR DESCRIPTION
Object do not guarantee the order of their keys so recreate the options order from the configured variations.